### PR TITLE
resolves #14 - comparison with a standard JVM implementation (Scala)

### DIFF
--- a/FSharp.HashCollections.sln
+++ b/FSharp.HashCollections.sln
@@ -13,6 +13,8 @@ Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "HashMap.Benchmarks", "test\
 EndProject
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharp.HashCollections.Unit", "test\FSharp.HashCollections.Unit\FSharp.HashCollections.Unit.fsproj", "{BD1D802A-5C2C-4788-B03C-89C94291BF28}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpTest", "test\PlatformComparison\FSharpTest\FSharpTest.fsproj", "{4AE298CA-2AD1-4458-A842-551D90DCAFF0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +64,18 @@ Global
 		{BD1D802A-5C2C-4788-B03C-89C94291BF28}.Release|x64.Build.0 = Release|Any CPU
 		{BD1D802A-5C2C-4788-B03C-89C94291BF28}.Release|x86.ActiveCfg = Release|Any CPU
 		{BD1D802A-5C2C-4788-B03C-89C94291BF28}.Release|x86.Build.0 = Release|Any CPU
+		{4AE298CA-2AD1-4458-A842-551D90DCAFF0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4AE298CA-2AD1-4458-A842-551D90DCAFF0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4AE298CA-2AD1-4458-A842-551D90DCAFF0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4AE298CA-2AD1-4458-A842-551D90DCAFF0}.Debug|x64.Build.0 = Debug|Any CPU
+		{4AE298CA-2AD1-4458-A842-551D90DCAFF0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4AE298CA-2AD1-4458-A842-551D90DCAFF0}.Debug|x86.Build.0 = Debug|Any CPU
+		{4AE298CA-2AD1-4458-A842-551D90DCAFF0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4AE298CA-2AD1-4458-A842-551D90DCAFF0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4AE298CA-2AD1-4458-A842-551D90DCAFF0}.Release|x64.ActiveCfg = Release|Any CPU
+		{4AE298CA-2AD1-4458-A842-551D90DCAFF0}.Release|x64.Build.0 = Release|Any CPU
+		{4AE298CA-2AD1-4458-A842-551D90DCAFF0}.Release|x86.ActiveCfg = Release|Any CPU
+		{4AE298CA-2AD1-4458-A842-551D90DCAFF0}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{B8CD14E2-5DC9-4A58-8271-E21F8DB6DCAD} = {583DE1CB-1CFA-4EEE-8FB7-D4A9A7ED0055}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Made for my own purposes the goal is to allow faster lookup table performance in
 4) Maintainable to an average F# developer.
     - For example minimising inheritance/object hierarchies and casting (unlike some other impl's I've seen), performant whilst still idiomatic code, etc.
     - Use F# strengths to increase performance further (e.g. inlining + DU's to avoid method calls and copying overhead affecting struct key performance).
+5) Performance at least at the same scale as other languages of the same class/abstraction level (e.g JVM, etc).
 
 **TLDR; Benefits of immutable collections while minimising the cost (e.g. performance, maintainable code, idiomatic code, etc).**
 
@@ -226,6 +227,40 @@ AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
 |                    AddToFSharpXMap |       10000000 |   875.8 ns | 12.69 ns | 11.87 ns |
 | AddToSystemCollectionsImmutableMap |       10000000 | 1,611.7 ns |  6.18 ns |  5.78 ns |
 ```
+
+## An outside .NET ecosystem comparison.
+
+This section is simply a guide to give a ballpark comparison figure on performance with implementations from other languages that have standard HAMT implementations for my own technical selection evaluation.
+
+Conclusion: The "Get" method where performance is significantly better as the collection scales up (at 10,000,000 FSharp collection is 7x faster, and Scala is 1.4x faster at building the initial hashmap). Note that most of the optimisation work I have done is around the "Get" method given my use case (lots of reads, fewer but still significant write load with large collections 500,000+ items).
+
+** FSharp - This Library **
+
+```
+Dotnet version: 5.0.400 (FSharp)
+FSharp Result [TestSize: 100, GetTime: 1, FromSeqTime: 10]
+FSharp Result [TestSize: 1000, GetTime: 0, FromSeqTime: 0]
+FSharp Result [TestSize: 10000, GetTime: 0, FromSeqTime: 3]
+FSharp Result [TestSize: 100000, GetTime: 3, FromSeqTime: 46]
+FSharp Result [TestSize: 500000, GetTime: 21, FromSeqTime: 237]
+FSharp Result [TestSize: 1000000, GetTime: 41, FromSeqTime: 474]
+FSharp Result [TestSize: 5000000, GetTime: 257, FromSeqTime: 3441]
+FSharp Result [TestSize: 10000000, GetTime: 719, FromSeqTime: 9557]
+```
+
+** Scala - Immutable HashMap **
+```
+Scala code runner version 3.0.2 -- Copyright 2002-2021, LAMP/EPFL
+Scala Result [TestSize: 100, GetTime: 1, FromSeqTime: 80]
+Scala Result [TestSize: 1000, GetTime: 1, FromSeqTime: 3]
+Scala Result [TestSize: 10000, GetTime: 2, FromSeqTime: 5]
+Scala Result [TestSize: 100000, GetTime: 16, FromSeqTime: 48]
+Scala Result [TestSize: 500000, GetTime: 115, FromSeqTime: 170]
+Scala Result [TestSize: 1000000, GetTime: 301, FromSeqTime: 428]
+Scala Result [TestSize: 5000000, GetTime: 2478, FromSeqTime: 2989]
+Scala Result [TestSize: 10000000, GetTime: 5537, FromSeqTime: 6470]
+```
+
 
 ## Design decisions that may affect consumers of this library
 

--- a/test/PlatformComparison/FSharpTest/FSharpTest.fsproj
+++ b/test/PlatformComparison/FSharpTest/FSharpTest.fsproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <WarnOn>3390;$(WarnOn)</WarnOn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\src\FSharp.HashCollections\FSharp.HashCollections.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/test/PlatformComparison/FSharpTest/Program.fs
+++ b/test/PlatformComparison/FSharpTest/Program.fs
@@ -1,0 +1,36 @@
+// Learn more about F# at http://docs.microsoft.com/dotnet/fsharp
+
+open System
+open FSharp.HashCollections
+open System.Diagnostics
+open System.Collections.Generic
+
+// Define a function to construct a message to print
+let runTest testSize =
+    let sourceData = Array.init testSize id
+
+    let populateSw = Stopwatch.StartNew()
+    let map = HashMap.ofSeq (sourceData |> Seq.map (fun x -> KeyValuePair.Create(int64 x, int64 x)))
+    populateSw.Stop()
+
+    let resultArray : int64 voption[] = Array.zeroCreate testSize
+    let sw = Stopwatch.StartNew()
+
+    for i = 0 to resultArray.Length - 1 do
+        resultArray.[i] <- map |> HashMap.tryFind (int64 i)
+
+    sw.Stop()
+
+    printfn $"FSharp Result [TestSize: {testSize}, GetTime: {sw.ElapsedMilliseconds}, FromSeqTime: {populateSw.ElapsedMilliseconds}]"
+
+[<EntryPoint>]
+let main argv =
+    runTest 100
+    runTest 1000
+    runTest 10000
+    runTest 100000
+    runTest 500000
+    runTest 1000000
+    runTest 5000000
+    runTest 10000000
+    0

--- a/test/PlatformComparison/ScalaTest/Program.scala
+++ b/test/PlatformComparison/ScalaTest/Program.scala
@@ -1,0 +1,38 @@
+import scala.collection.immutable.HashMap;
+
+object Benchmarker {
+    def runTest(testSize: Int) = {
+        val a = Array.range(0, testSize);
+
+        val writeStartTime = System.nanoTime();
+
+        val m = a.map(i => i.toLong -> i.toLong).toMap;
+        val endWriteTime = System.nanoTime();
+
+        val startTime = System.nanoTime();
+
+        val result = new Array[Long](testSize);
+
+        for (i <- a) {
+            result(i) = m.get(i.toLong).get
+        }
+
+        val endTime = System.nanoTime();
+
+        var timeIntervalGet = (endTime - startTime) / 1000000; // To milliseconds
+        var timeIntervalWrite = (endWriteTime - writeStartTime) / 1000000; // To milliseconds
+
+        println(s"Scala Result [TestSize: $testSize, GetTime: $timeIntervalGet, FromSeqTime: $timeIntervalWrite]");
+    }
+}
+
+object Program extends App {
+    Benchmarker.runTest(100);
+    Benchmarker.runTest(1000);
+    Benchmarker.runTest(10000);
+    Benchmarker.runTest(100000);
+    Benchmarker.runTest(500000);
+    Benchmarker.runTest(1000000);
+    Benchmarker.runTest(5000000);
+    Benchmarker.runTest(10000000);
+}

--- a/test/PlatformComparison/ScalaTest/run.sh
+++ b/test/PlatformComparison/ScalaTest/run.sh
@@ -1,0 +1,1 @@
+scalac Program.scala && scala Program

--- a/test/PlatformComparison/runAll.sh
+++ b/test/PlatformComparison/runAll.sh
@@ -1,0 +1,8 @@
+cd FSharpTest
+echo "Dotnet version:" `dotnet --version`
+dotnet run -c Release
+cd ..
+cd ScalaTest
+scala --version
+scalac ./Program.scala && scala Program
+cd ..


### PR DESCRIPTION
Added some quick comparison scripts to test performance against other platforms for my own evaluation. Figured the results are useful to keep on the repository.

They have been put on the README.md as a separate section.

Results of the quick test are shown here.

```
Dotnet version: 5.0.400
FSharp Result [TestSize: 100, GetTime: 1, FromSeqTime: 10]
FSharp Result [TestSize: 1000, GetTime: 0, FromSeqTime: 0]
FSharp Result [TestSize: 10000, GetTime: 0, FromSeqTime: 3]
FSharp Result [TestSize: 100000, GetTime: 3, FromSeqTime: 46]
FSharp Result [TestSize: 500000, GetTime: 21, FromSeqTime: 237]
FSharp Result [TestSize: 1000000, GetTime: 41, FromSeqTime: 474]
FSharp Result [TestSize: 5000000, GetTime: 257, FromSeqTime: 3441]
FSharp Result [TestSize: 10000000, GetTime: 719, FromSeqTime: 9557]

Scala code runner version 3.0.2 -- Copyright 2002-2021, LAMP/EPFL
Scala Result [TestSize: 100, GetTime: 1, FromSeqTime: 80]
Scala Result [TestSize: 1000, GetTime: 1, FromSeqTime: 3]
Scala Result [TestSize: 10000, GetTime: 2, FromSeqTime: 5]
Scala Result [TestSize: 100000, GetTime: 16, FromSeqTime: 48]
Scala Result [TestSize: 500000, GetTime: 115, FromSeqTime: 170]
Scala Result [TestSize: 1000000, GetTime: 301, FromSeqTime: 428]
Scala Result [TestSize: 5000000, GetTime: 2478, FromSeqTime: 2989]
Scala Result [TestSize: 10000000, GetTime: 5537, FromSeqTime: 6470]
```